### PR TITLE
fix:  update DI by providing kafka config

### DIFF
--- a/internal/pkg/kafka/kafka.go
+++ b/internal/pkg/kafka/kafka.go
@@ -5,13 +5,14 @@ import (
 )
 
 type ProducerConfig struct {
-    BootstrapServers string
-    Topic            string
+	BootstrapServers string
+	Topic            string
 }
 
 // NewProducer membuat instance produsen Kafka baru.
-func NewProducer(bootstrapServers string) (*kafka.Producer, error) {
-	return kafka.NewProducer(&kafka.ConfigMap{"bootstrap.servers": bootstrapServers})
+// Konfigurasi diambil dari ProducerConfig untuk memudahkan injeksi dependensi.
+func NewProducer(cfg ProducerConfig) (*kafka.Producer, error) {
+	return kafka.NewProducer(&kafka.ConfigMap{"bootstrap.servers": cfg.BootstrapServers})
 }
 
 // NewConsumer membuat instance konsumen Kafka baru.

--- a/internal/services/auth/event/kafka_producer.go
+++ b/internal/services/auth/event/kafka_producer.go
@@ -6,23 +6,26 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	ckafka "github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/dpalhz/microservice-exp-with-go/internal/pkg/kafka"
 	"github.com/dpalhz/microservice-exp-with-go/internal/services/auth/domain"
 	"github.com/google/uuid"
 )
 
 type KafkaEventProducer struct {
-	producer *kafka.Producer
+	producer *ckafka.Producer
 	topic    string
 	log      *slog.Logger
 }
 
-func NewKafkaEventProducer(p *kafka.Producer, topic string, log *slog.Logger) *KafkaEventProducer {
-	return &KafkaEventProducer{producer: p, topic: topic, log: log}
+// NewKafkaEventProducer membuat producer event berbasis Kafka.
+// Konfigurasi topik diambil dari kafka.ProducerConfig sehingga mudah di-wire.
+func NewKafkaEventProducer(p *ckafka.Producer, cfg kafka.ProducerConfig, log *slog.Logger) *KafkaEventProducer {
+	return &KafkaEventProducer{producer: p, topic: cfg.Topic, log: log}
 }
 
 type UserRegisteredEvent struct {
-	UserID       uuid.UUID    `json:"user_id"`
+	UserID       uuid.UUID `json:"user_id"`
 	Email        string    `json:"email"`
 	FullName     string    `json:"full_name"`
 	RegisteredAt time.Time `json:"registered_at"`
@@ -37,12 +40,12 @@ func (p *KafkaEventProducer) ProduceUserRegistered(ctx context.Context, user *do
 	}
 
 	payload, err := json.Marshal(event)
-	if err!= nil {
+	if err != nil {
 		return err
 	}
 
-	return p.producer.Produce(&kafka.Message{
-		TopicPartition: kafka.TopicPartition{Topic: &p.topic, Partition: int32(kafka.PartitionAny)},
+	return p.producer.Produce(&ckafka.Message{
+		TopicPartition: ckafka.TopicPartition{Topic: &p.topic, Partition: int32(ckafka.PartitionAny)},
 		Value:          payload,
 	}, nil)
 }


### PR DESCRIPTION
## Summary
- wire expects a `string` but only `ProducerConfig` is available
- make `NewProducer` accept `ProducerConfig`
- make `NewKafkaEventProducer` use the same config for topic

## Testing
- `go vet ./...` *(fails: golang toolchain download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6883abf2fa788320bf126c14f2d0f33f