### PR TITLE
Add email service and 2FA workflow

### DIFF
--- a/cmd/email/main.go
+++ b/cmd/email/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"log/slog"
+
+	"github.com/dpalhz/microservice-exp-with-go/internal/pkg/config"
+	"github.com/dpalhz/microservice-exp-with-go/internal/pkg/logger"
+	"github.com/dpalhz/microservice-exp-with-go/internal/services/email/app"
+	"github.com/dpalhz/microservice-exp-with-go/internal/services/email/app/di"
+)
+
+func main() {
+	log := logger.New()
+	if err := config.LoadConfig("./configs", "email"); err != nil {
+		log.Error("failed load config", slog.String("error", err.Error()))
+		return
+	}
+	application, cleanup, err := di.InitializeApp(log)
+	if err != nil {
+		log.Error("init app", slog.String("error", err.Error()))
+		return
+	}
+	defer cleanup()
+	if err := application.Start(); err != nil {
+		log.Error("start", slog.String("error", err.Error()))
+	}
+}

--- a/configs/email.yaml
+++ b/configs/email.yaml
@@ -1,0 +1,10 @@
+kafka:
+  brokers: "kafka:9092"
+  topic: "user-events"
+
+db:
+  user: "admin"
+  password: "secret"
+  host: "postgres"
+  port: "5432"
+  name: "microservices_db"

--- a/internal/services/auth/app/app.go
+++ b/internal/services/auth/app/app.go
@@ -28,8 +28,8 @@ func New(h *handler.FiberHandler, db *gorm.DB, log *slog.Logger, cfg ServerConfi
 	server.Use(cors.New())
 	h.RegisterRoutes(server)
 
-	// Migrasi otomatis domain User
-	db.AutoMigrate(&domain.User{})
+	// Migrasi otomatis domain User dan VerificationCode
+	db.AutoMigrate(&domain.User{}, &domain.VerificationCode{})
 
 	return &App{
 		server: server,

--- a/internal/services/auth/app/di/wire.go
+++ b/internal/services/auth/app/di/wire.go
@@ -25,12 +25,14 @@ func InitializeApp(log *slog.Logger) (*app.App, func(), error) {
 		wire.Bind(new(usecase.EventProducer), new(*event.KafkaEventProducer)),
 		wire.Bind(new(usecase.TokenGenerator), new(*token.JWTGenerator)),
 		wire.Bind(new(usecase.SessionStore), new(*session.RedisSessionStore)),
+		wire.Bind(new(usecase.VerificationRepository), new(*repository.PostgresVerificationRepository)),
 
 		// ✅ PROVIDER CONSTRUCTORS
 		app.New,
 		handler.NewFiberHandler,
 		usecase.NewUserUsecase,
 		repository.NewPostgresUserRepository,
+		repository.NewPostgresVerificationRepository,
 		event.NewKafkaEventProducer,
 		token.NewJWTGenerator,
 		session.NewRedisSessionStore,

--- a/internal/services/auth/domain/user.go
+++ b/internal/services/auth/domain/user.go
@@ -10,17 +10,19 @@ import (
 )
 
 type User struct {
-	ID        uuid.UUID `gorm:"type:uuid;primaryKey"`
-	FullName  string    `gorm:"not null"`
-	Email     string    `gorm:"uniqueIndex;not null"`
-	Password  string    `gorm:"not null"`
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID         uuid.UUID `gorm:"type:uuid;primaryKey"`
+	FullName   string    `gorm:"not null"`
+	Email      string    `gorm:"uniqueIndex;not null"`
+	Password   string    `gorm:"not null"`
+	MFAEnabled bool
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
 }
 
 var (
-	ErrInvalidCredentials = errors.New("invalid credentials")
-	ErrUserNotFound       = errors.New("user not found")
+	ErrInvalidCredentials   = errors.New("invalid credentials")
+	ErrUserNotFound         = errors.New("user not found")
+	ErrVerificationRequired = errors.New("verification required")
 )
 
 // HashPassword mengenkripsi kata sandi menggunakan bcrypt.

--- a/internal/services/auth/domain/verification.go
+++ b/internal/services/auth/domain/verification.go
@@ -1,0 +1,28 @@
+package domain
+
+import (
+	"github.com/google/uuid"
+	"time"
+)
+
+type VerificationPurpose string
+
+const (
+	PurposeRegister  VerificationPurpose = "register"
+	PurposeLogin     VerificationPurpose = "login_2fa"
+	PurposeEnable2FA VerificationPurpose = "enable_2fa"
+)
+
+// VerificationCode stores OTP for various purposes
+// gorm model.
+type VerificationCode struct {
+	ID           uuid.UUID           `gorm:"type:uuid;primaryKey"`
+	UserID       uuid.UUID           `gorm:"type:uuid;index"`
+	Code         string              `gorm:"size:6"`
+	Purpose      VerificationPurpose `gorm:"type:varchar(20)"`
+	Status       string              `gorm:"type:varchar(10)"`
+	AttemptCount int
+	ExpiresAt    time.Time
+	CreatedAt    time.Time
+	UsedAt       *time.Time
+}

--- a/internal/services/auth/dto/enable_2fa.go
+++ b/internal/services/auth/dto/enable_2fa.go
@@ -1,0 +1,8 @@
+package dto
+
+import "github.com/google/uuid"
+
+type Enable2FARequest struct {
+	UserID uuid.UUID `json:"user_id"`
+	Code   string    `json:"code"`
+}

--- a/internal/services/auth/dto/verify.go
+++ b/internal/services/auth/dto/verify.go
@@ -1,0 +1,17 @@
+package dto
+
+import (
+	"github.com/dpalhz/microservice-exp-with-go/internal/services/auth/domain"
+	"github.com/google/uuid"
+)
+
+type VerifyRequest struct {
+	UserID  uuid.UUID                  `json:"user_id"`
+	Code    string                     `json:"code"`
+	Purpose domain.VerificationPurpose `json:"purpose"`
+}
+
+type VerifyResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+}

--- a/internal/services/auth/handler/fiber_handler.go
+++ b/internal/services/auth/handler/fiber_handler.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 
 	"github.com/dpalhz/microservice-exp-with-go/internal/pkg/apiresponse"
+	"github.com/dpalhz/microservice-exp-with-go/internal/services/auth/domain"
 	"github.com/dpalhz/microservice-exp-with-go/internal/services/auth/dto"
 	"github.com/dpalhz/microservice-exp-with-go/internal/services/auth/usecase"
 
@@ -23,6 +24,8 @@ func (h *FiberHandler) RegisterRoutes(app *fiber.App) {
 	api := app.Group("/api/v1/auth")
 	api.Post("/register", h.Register)
 	api.Post("/login", h.Login)
+	api.Post("/verify", h.Verify)
+	api.Post("/enable-2fa", h.Enable2FA)
 }
 
 func (h *FiberHandler) Register(c *fiber.Ctx) error {
@@ -53,4 +56,28 @@ func (h *FiberHandler) Login(c *fiber.Ctx) error {
 
 	resp := dto.LoginResponse{AccessToken: accessToken, RefreshToken: refreshToken}
 	return c.JSON(apiresponse.Success(resp))
+}
+
+func (h *FiberHandler) Verify(c *fiber.Ctx) error {
+	var req dto.VerifyRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(http.StatusBadRequest).JSON(apiresponse.Error("cannot parse json"))
+	}
+	access, refresh, err := h.uc.VerifyCode(c.Context(), req.UserID, req.Code, req.Purpose)
+	if err != nil {
+		return c.Status(http.StatusUnauthorized).JSON(apiresponse.Error("invalid code"))
+	}
+	return c.JSON(apiresponse.Success(dto.VerifyResponse{AccessToken: access, RefreshToken: refresh}))
+}
+
+func (h *FiberHandler) Enable2FA(c *fiber.Ctx) error {
+	var req dto.VerifyRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(http.StatusBadRequest).JSON(apiresponse.Error("cannot parse json"))
+	}
+	_, _, err := h.uc.VerifyCode(c.Context(), req.UserID, req.Code, domain.PurposeEnable2FA)
+	if err != nil {
+		return c.Status(http.StatusUnauthorized).JSON(apiresponse.Error("invalid code"))
+	}
+	return c.JSON(apiresponse.Success("2fa enabled"))
 }

--- a/internal/services/auth/repository/postgres_user_repo.go
+++ b/internal/services/auth/repository/postgres_user_repo.go
@@ -23,11 +23,26 @@ func (r *PostgresUserRepository) Create(ctx context.Context, user *domain.User) 
 
 func (r *PostgresUserRepository) FindByEmail(ctx context.Context, email string) (*domain.User, error) {
 	var user domain.User
-	if err := r.db.WithContext(ctx).Where("email =?", email).First(&user).Error; err!= nil {
+	if err := r.db.WithContext(ctx).Where("email =?", email).First(&user).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, domain.ErrUserNotFound
 		}
 		return nil, err
 	}
 	return &user, nil
+}
+
+func (r *PostgresUserRepository) FindByID(ctx context.Context, id uuid.UUID) (*domain.User, error) {
+	var user domain.User
+	if err := r.db.WithContext(ctx).First(&user, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrUserNotFound
+		}
+		return nil, err
+	}
+	return &user, nil
+}
+
+func (r *PostgresUserRepository) Update(ctx context.Context, user *domain.User) error {
+	return r.db.WithContext(ctx).Save(user).Error
 }

--- a/internal/services/auth/repository/postgres_verification_repo.go
+++ b/internal/services/auth/repository/postgres_verification_repo.go
@@ -1,0 +1,37 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/dpalhz/microservice-exp-with-go/internal/services/auth/domain"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type PostgresVerificationRepository struct {
+	db *gorm.DB
+}
+
+func NewPostgresVerificationRepository(db *gorm.DB) *PostgresVerificationRepository {
+	return &PostgresVerificationRepository{db: db}
+}
+
+func (r *PostgresVerificationRepository) Create(ctx context.Context, v *domain.VerificationCode) error {
+	return r.db.WithContext(ctx).Create(v).Error
+}
+
+func (r *PostgresVerificationRepository) FindValid(ctx context.Context, userID uuid.UUID, purpose domain.VerificationPurpose, code string) (*domain.VerificationCode, error) {
+	var vc domain.VerificationCode
+	if err := r.db.WithContext(ctx).Where("user_id = ? AND purpose = ? AND code = ? AND status = ? AND expires_at > now()", userID, purpose, code, "UNUSED").First(&vc).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, gorm.ErrRecordNotFound
+		}
+		return nil, err
+	}
+	return &vc, nil
+}
+
+func (r *PostgresVerificationRepository) Update(ctx context.Context, v *domain.VerificationCode) error {
+	return r.db.WithContext(ctx).Save(v).Error
+}

--- a/internal/services/auth/usecase/interfaces.go
+++ b/internal/services/auth/usecase/interfaces.go
@@ -10,10 +10,13 @@ import (
 type UserRepository interface {
 	Create(ctx context.Context, user *domain.User) error
 	FindByEmail(ctx context.Context, email string) (*domain.User, error)
+	FindByID(ctx context.Context, id uuid.UUID) (*domain.User, error)
+	Update(ctx context.Context, user *domain.User) error
 }
 
 type EventProducer interface {
 	ProduceUserRegistered(ctx context.Context, user *domain.User) error
+	ProduceEmailVerification(ctx context.Context, email string, userID uuid.UUID, code string, purpose domain.VerificationPurpose) error
 }
 
 type TokenGenerator interface {
@@ -23,4 +26,10 @@ type TokenGenerator interface {
 type SessionStore interface {
 	Store(ctx context.Context, token string, userID uuid.UUID) error
 	GetUserID(ctx context.Context, token string) (uuid.UUID, error)
+}
+
+type VerificationRepository interface {
+	Create(ctx context.Context, v *domain.VerificationCode) error
+	FindValid(ctx context.Context, userID uuid.UUID, purpose domain.VerificationPurpose, code string) (*domain.VerificationCode, error)
+	Update(ctx context.Context, v *domain.VerificationCode) error
 }

--- a/internal/services/auth/usecase/user_usecase.go
+++ b/internal/services/auth/usecase/user_usecase.go
@@ -2,7 +2,12 @@ package usecase
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"math/rand"
+	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/dpalhz/microservice-exp-with-go/internal/services/auth/domain"
 )
@@ -12,11 +17,47 @@ type UserUsecase struct {
 	producer EventProducer
 	tokenGen TokenGenerator
 	session  SessionStore
+	verRepo  VerificationRepository
 	log      *slog.Logger
 }
 
-func NewUserUsecase(repo UserRepository, producer EventProducer, tokenGen TokenGenerator, session SessionStore, log *slog.Logger) *UserUsecase {
-	return &UserUsecase{userRepo: repo, producer: producer, tokenGen: tokenGen, session: session, log: log}
+func NewUserUsecase(repo UserRepository, producer EventProducer, tokenGen TokenGenerator, session SessionStore, verRepo VerificationRepository, log *slog.Logger) *UserUsecase {
+	return &UserUsecase{userRepo: repo, producer: producer, tokenGen: tokenGen, session: session, verRepo: verRepo, log: log}
+}
+
+func generateCode() string {
+	rand.Seed(time.Now().UnixNano())
+	return fmt.Sprintf("%06d", rand.Intn(1000000))
+}
+
+func (uc *UserUsecase) VerifyCode(ctx context.Context, userID uuid.UUID, code string, purpose domain.VerificationPurpose) (string, string, error) {
+	vc, err := uc.verRepo.FindValid(ctx, userID, purpose, code)
+	if err != nil {
+		return "", "", domain.ErrInvalidCredentials
+	}
+	vc.Status = "USED"
+	now := time.Now()
+	vc.UsedAt = &now
+	if err := uc.verRepo.Update(ctx, vc); err != nil {
+		uc.log.Error("failed update verification", slog.String("error", err.Error()))
+	}
+
+	if purpose == domain.PurposeEnable2FA {
+		user, err := uc.userRepo.FindByID(ctx, vc.UserID)
+		if err == nil {
+			user.MFAEnabled = true
+			_ = uc.userRepo.Update(ctx, user)
+		}
+	}
+
+	accessToken, refreshToken, err := uc.tokenGen.GenerateTokens(userID)
+	if err != nil {
+		return "", "", err
+	}
+	if err := uc.session.Store(ctx, refreshToken, userID); err != nil {
+		uc.log.Error("failed to store refresh token", slog.String("error", err.Error()))
+	}
+	return accessToken, refreshToken, nil
 }
 
 func (uc *UserUsecase) Register(ctx context.Context, fullName, email, password string) (*domain.User, error) {
@@ -32,8 +73,24 @@ func (uc *UserUsecase) Register(ctx context.Context, fullName, email, password s
 	}
 
 	if err := uc.producer.ProduceUserRegistered(ctx, user); err != nil {
-		// Log error tapi jangan gagalkan registrasi
 		uc.log.Error("Gagal memproduksi event UserRegistered", slog.String("error", err.Error()))
+	}
+
+	// generate verification code for registration
+	code := generateCode()
+	vc := &domain.VerificationCode{
+		ID:        uuid.New(),
+		UserID:    user.ID,
+		Code:      code,
+		Purpose:   domain.PurposeRegister,
+		Status:    "UNUSED",
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+		CreatedAt: time.Now(),
+	}
+	if err := uc.verRepo.Create(ctx, vc); err == nil {
+		if err := uc.producer.ProduceEmailVerification(ctx, user.Email, user.ID, code, domain.PurposeRegister); err != nil {
+			uc.log.Error("send email event failed", slog.String("error", err.Error()))
+		}
 	}
 
 	return user, nil
@@ -47,6 +104,25 @@ func (uc *UserUsecase) Login(ctx context.Context, email, password string) (acces
 
 	if !user.CheckPassword(password) {
 		return "", "", domain.ErrInvalidCredentials
+	}
+
+	if user.MFAEnabled {
+		code := generateCode()
+		vc := &domain.VerificationCode{
+			ID:        uuid.New(),
+			UserID:    user.ID,
+			Code:      code,
+			Purpose:   domain.PurposeLogin,
+			Status:    "UNUSED",
+			ExpiresAt: time.Now().Add(5 * time.Minute),
+			CreatedAt: time.Now(),
+		}
+		if err := uc.verRepo.Create(ctx, vc); err == nil {
+			if err := uc.producer.ProduceEmailVerification(ctx, user.Email, user.ID, code, domain.PurposeLogin); err != nil {
+				uc.log.Error("send email event failed", slog.String("error", err.Error()))
+			}
+		}
+		return "", "", domain.ErrVerificationRequired
 	}
 
 	accessToken, refreshToken, err = uc.tokenGen.GenerateTokens(user.ID)

--- a/internal/services/email/app/app.go
+++ b/internal/services/email/app/app.go
@@ -1,0 +1,61 @@
+package app
+
+import (
+	"context"
+	"github.com/dpalhz/microservice-exp-with-go/internal/pkg/database"
+	"github.com/dpalhz/microservice-exp-with-go/internal/pkg/kafka"
+	"github.com/dpalhz/microservice-exp-with-go/internal/services/email/event"
+	"github.com/dpalhz/microservice-exp-with-go/internal/services/email/repository"
+	"github.com/spf13/viper"
+	"gorm.io/gorm"
+	"log/slog"
+)
+
+type App struct {
+	consumer *event.KafkaConsumer
+	log      *slog.Logger
+	topic    string
+}
+
+func New(db *gorm.DB, consumer *event.KafkaConsumer, log *slog.Logger, cfg ServerConfig) *App {
+	return &App{consumer: consumer, log: log, topic: cfg.Topic}
+}
+
+func (a *App) Start() error {
+	a.log.Info("email service start")
+	return a.consumer.Start(context.Background(), a.topic)
+}
+
+// config providers
+
+type ServerConfig struct{ Topic string }
+
+func ProvideServerConfig() ServerConfig { return ServerConfig{Topic: viper.GetString("kafka.topic")} }
+
+func ProvideDBConfig() database.Config {
+	return database.Config{
+		User:     viper.GetString("db.user"),
+		Password: viper.GetString("db.password"),
+		Host:     viper.GetString("db.host"),
+		Port:     viper.GetString("db.port"),
+		DBName:   viper.GetString("db.name"),
+	}
+}
+
+func ProvideKafkaConfig() kafka.ProducerConfig {
+	return kafka.ProducerConfig{BootstrapServers: viper.GetString("kafka.brokers"), Topic: viper.GetString("kafka.topic")}
+}
+
+func ProvideDB(dbCfg database.Config) (*gorm.DB, error) {
+	return database.NewPostgresDB(dbCfg)
+}
+
+func ProvideConsumer(cfg kafka.ProducerConfig, repo *repository.PostgresLogRepository, log *slog.Logger) (*event.KafkaConsumer, func(), error) {
+	c, err := kafka.NewConsumer(cfg.BootstrapServers, "email-service")
+	if err != nil {
+		return nil, nil, err
+	}
+	consumer := event.NewKafkaConsumer(c, repo, log)
+	cleanup := func() { c.Close() }
+	return consumer, cleanup, nil
+}

--- a/internal/services/email/app/di/wire.go
+++ b/internal/services/email/app/di/wire.go
@@ -1,0 +1,31 @@
+//go:build wireinject
+// +build wireinject
+
+package di
+
+import (
+	"log/slog"
+
+	"github.com/dpalhz/microservice-exp-with-go/internal/pkg/database"
+	"github.com/dpalhz/microservice-exp-with-go/internal/pkg/kafka"
+	"github.com/dpalhz/microservice-exp-with-go/internal/services/email/app"
+	"github.com/dpalhz/microservice-exp-with-go/internal/services/email/event"
+	"github.com/dpalhz/microservice-exp-with-go/internal/services/email/repository"
+	"github.com/google/wire"
+)
+
+func InitializeApp(log *slog.Logger) (*app.App, func(), error) {
+	wire.Build(
+		app.New,
+		repository.NewPostgresLogRepository,
+		event.NewKafkaConsumer,
+		database.NewPostgresDB,
+		kafka.NewConsumer,
+		app.ProvideDBConfig,
+		app.ProvideKafkaConfig,
+		app.ProvideServerConfig,
+		app.ProvideDB,
+		app.ProvideConsumer,
+	)
+	return &app.App{}, nil, nil
+}

--- a/internal/services/email/domain/email_log.go
+++ b/internal/services/email/domain/email_log.go
@@ -1,0 +1,16 @@
+package domain
+
+import (
+	"github.com/google/uuid"
+	"time"
+)
+
+type EmailLog struct {
+	ID        uuid.UUID `gorm:"type:uuid;primaryKey"`
+	To        string
+	Subject   string
+	Body      string
+	Status    string
+	ErrorMsg  string
+	CreatedAt time.Time
+}

--- a/internal/services/email/event/kafka_consumer.go
+++ b/internal/services/email/event/kafka_consumer.go
@@ -1,0 +1,53 @@
+package event
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/google/uuid"
+	"log/slog"
+
+	ckafka "github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	authdomain "github.com/dpalhz/microservice-exp-with-go/internal/services/auth/domain"
+	"github.com/dpalhz/microservice-exp-with-go/internal/services/email/domain"
+	"github.com/dpalhz/microservice-exp-with-go/internal/services/email/repository"
+)
+
+type KafkaConsumer struct {
+	consumer *ckafka.Consumer
+	repo     *repository.PostgresLogRepository
+	log      *slog.Logger
+}
+
+type EmailVerificationEvent struct {
+	UserID  uuid.UUID                      `json:"user_id"`
+	Email   string                         `json:"email"`
+	Code    string                         `json:"code"`
+	Purpose authdomain.VerificationPurpose `json:"purpose"`
+}
+
+func NewKafkaConsumer(c *ckafka.Consumer, repo *repository.PostgresLogRepository, log *slog.Logger) *KafkaConsumer {
+	return &KafkaConsumer{consumer: c, repo: repo, log: log}
+}
+
+func (kc *KafkaConsumer) Start(ctx context.Context, topic string) error {
+	if err := kc.consumer.SubscribeTopics([]string{topic}, nil); err != nil {
+		return err
+	}
+	for {
+		msg, err := kc.consumer.ReadMessage(-1)
+		if err != nil {
+			kc.log.Error("consumer error", slog.String("error", err.Error()))
+			continue
+		}
+		var evt EmailVerificationEvent
+		if err := json.Unmarshal(msg.Value, &evt); err != nil {
+			kc.log.Error("unmarshal", slog.String("error", err.Error()))
+			continue
+		}
+		// simulate email send
+		el := domain.EmailLog{To: evt.Email, Subject: "Your Code", Body: evt.Code, Status: "SENT", CreatedAt: msg.Timestamp}
+		if err := kc.repo.Create(ctx, &el); err != nil {
+			kc.log.Error("save log", slog.String("error", err.Error()))
+		}
+	}
+}

--- a/internal/services/email/repository/postgres_log_repo.go
+++ b/internal/services/email/repository/postgres_log_repo.go
@@ -1,0 +1,22 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/dpalhz/microservice-exp-with-go/internal/services/email/domain"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type PostgresLogRepository struct{ db *gorm.DB }
+
+func NewPostgresLogRepository(db *gorm.DB) *PostgresLogRepository {
+	return &PostgresLogRepository{db: db}
+}
+
+func (r *PostgresLogRepository) Create(ctx context.Context, log *domain.EmailLog) error {
+	if log.ID == uuid.Nil {
+		log.ID = uuid.New()
+	}
+	return r.db.WithContext(ctx).Create(log).Error
+}


### PR DESCRIPTION
## Summary
- implement new field `MFAEnabled` for users
- add verification codes and login flow requiring code when 2FA enabled
- generate verification codes on registration and login, publish Kafka event
- create email service with Kafka consumer storing send logs in DB
- provide DTOs and endpoints for verifying codes and enabling 2FA
- supply email service config

## Testing
- `go build ./...` *(fails: forbidden to download modules)*
- `go test ./...` *(fails: forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_688518920a5483208a10ceb93b94de4e